### PR TITLE
Add MVC to services to fix the swagger UI

### DIFF
--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -39,6 +39,7 @@ namespace area
 			var appSettings = appSettingsSection.Get<AppSettings>();
 			var key = Encoding.ASCII.GetBytes(appSettings.Secret);
 
+			services.AddMvc();
 			services.AddCors();
 
 			services.AddAuthentication(x => {


### PR DESCRIPTION
Swagger UI was broken because MVC was not added to the services, so I fixed according to [this comment](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/299#issuecomment-280987005)